### PR TITLE
fix default file name in translation

### DIFF
--- a/autotrans/main.py
+++ b/autotrans/main.py
@@ -100,7 +100,7 @@ def translate_one_line(
     return ret
 
 
-def translate_one_page(page="../contents/traditional-mandarin/序章 數位觀照.md"):
+def translate_one_page(page="../contents/traditional-mandarin/01-數位觀照.md"):
     print("Translating page: " + page)
     basename = os.path.basename(page)
     OUTFILE = f"../contents/japanese-auto/{basename}"


### PR DESCRIPTION
It seems that the md files are renamed on this commit: https://github.com/pluralitybook/plurality/commit/7b42754420ba435b3f5674e95ae9c3139aaa1d6c?short_path=c60cc5c#diff-c60cc5cc3f16f3e518012ebc09955b1f62c92b9092f00461c6d16f1afd029881

Thank you for creating such a great forum for discussion.